### PR TITLE
Use embedded bindings on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,4 @@ rust-version = "1.64"
 libc = "0.2.141"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.48.0", features = [
-    "Win32_System_SystemInformation",
-    "Win32_Foundation",
-] }
+windows-targets = "0.48"


### PR DESCRIPTION
The giant `windows` crate was being pulled in for a single function, which is kind of wasteful, this just embeds the one function binding and one constant binding.

This reduces compile time by ~1s which was not the biggest deal, the problem is more that the dependency was massive overkill generally (ie it expands to ~172MiB of source code when the crate tarball is unpacked).