### PR TITLE
Truncate instead of resize in unix impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ fn gethostname_impl() -> OsString {
     // doesn't specify whether there's a NUL byte at the end, so if we didn't
     // check we might read from memory that's not ours.
     let end = buffer.iter().position(|&b| b == 0).unwrap_or(buffer.len());
-    buffer.resize(end, 0);
+    buffer.truncate(end);
     OsString::from_vec(buffer)
 }
 


### PR DESCRIPTION
It should not change performance much - in fact a quick check on godbolt reveals that [two versions likely compile to the same assembly](https://godbolt.org/z/KdTde1964) - but I believe it communicates the intent more clearly.