### PR TITLE
Add WASM/WASI support with fixed hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+- Add WASM/WASI support with fixed hostname
+
 ## [1.0.1] – 2025-03-25
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@ use std::ffi::OsString;
 /// name would result in a wrong buffer size which could cause this function to
 /// panic.
 ///
+/// On WASM/WASI platforms, returns a fixed hostname "wasm-host" since these
+/// environments typically don't have access to the actual hostname.
+///
 /// Note that this host name does not have a well-defined meaning in terms of
 /// network name resolution.  Specifically, it's not guaranteed that the
 /// returned name can be resolved in any particular way, e.g. DNS.
@@ -53,6 +56,10 @@ pub fn gethostname() -> OsString {
     #[cfg(windows)]
     {
         get_computer_physical_dns_hostname()
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        OsString::from("wasm-host")
     }
 }
 


### PR DESCRIPTION
The `gethostname()` function now returns "wasm-host" for [wasm32-wasip2](https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32-wasip2.html) WASM/WASI Preview 2 targets since these environments typically don't have access to the actual hostname.

Fixes the following error for `cargo build --target wasm32-wasip2`:
```
error[E0425]: cannot find function `gethostname_impl` in this scope
  --> /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gethostname-0.4.3/src/lib.rs:57:5
   |
57 |     gethostname_impl()
   |     ^^^^^^^^^^^^^^^^ not found in this scope

For more information about this error, try `rustc --explain E0425`.
error: could not compile `gethostname` (lib) due to 1 previous error
```